### PR TITLE
Add patient photo upload support

### DIFF
--- a/consultorio-backend/Controllers/PacientesController.cs
+++ b/consultorio-backend/Controllers/PacientesController.cs
@@ -162,6 +162,7 @@ namespace ConsultorioMedico.API.Controllers
                 pacienteExistente.TelefonoEmergencia = paciente.TelefonoEmergencia;
                 pacienteExistente.TipoSangre = paciente.TipoSangre;
                 pacienteExistente.Alergias = paciente.Alergias;
+                pacienteExistente.FotoUrl = paciente.FotoUrl;
 
                 await _context.SaveChangesAsync();
 

--- a/consultorio-backend/Controllers/PacientesController.cs
+++ b/consultorio-backend/Controllers/PacientesController.cs
@@ -1,4 +1,6 @@
-﻿using ConsultorioMedico.API.Data;
+﻿using System;
+using System.IO;
+using ConsultorioMedico.API.Data;
 using ConsultorioMedico.API.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -101,6 +103,31 @@ namespace ConsultorioMedico.API.Controllers
                 paciente.FechaRegistro = DateTime.Now;
                 paciente.Estado = true;
 
+                if (!string.IsNullOrWhiteSpace(paciente.FotoUrl))
+                {
+                    if (!EsDataUrl(paciente.FotoUrl))
+                    {
+                        return BadRequest(new
+                        {
+                            success = false,
+                            message = "El formato de la imagen no es válido."
+                        });
+                    }
+
+                    try
+                    {
+                        paciente.FotoUrl = await GuardarFotoAsync(paciente.FotoUrl);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        return BadRequest(new
+                        {
+                            success = false,
+                            message = ex.Message
+                        });
+                    }
+                }
+
                 _context.Pacientes.Add(paciente);
                 await _context.SaveChangesAsync();
 
@@ -162,7 +189,33 @@ namespace ConsultorioMedico.API.Controllers
                 pacienteExistente.TelefonoEmergencia = paciente.TelefonoEmergencia;
                 pacienteExistente.TipoSangre = paciente.TipoSangre;
                 pacienteExistente.Alergias = paciente.Alergias;
-                pacienteExistente.FotoUrl = paciente.FotoUrl;
+
+                if (string.IsNullOrWhiteSpace(paciente.FotoUrl))
+                {
+                    EliminarFotoExistente(pacienteExistente.FotoUrl);
+                    pacienteExistente.FotoUrl = null;
+                }
+                else if (EsDataUrl(paciente.FotoUrl))
+                {
+                    try
+                    {
+                        var nuevaFoto = await GuardarFotoAsync(paciente.FotoUrl);
+                        EliminarFotoExistente(pacienteExistente.FotoUrl);
+                        pacienteExistente.FotoUrl = nuevaFoto;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        return BadRequest(new
+                        {
+                            success = false,
+                            message = ex.Message
+                        });
+                    }
+                }
+                else
+                {
+                    pacienteExistente.FotoUrl = paciente.FotoUrl;
+                }
 
                 await _context.SaveChangesAsync();
 
@@ -180,6 +233,101 @@ namespace ConsultorioMedico.API.Controllers
                     message = "Error al actualizar el paciente",
                     error = ex.Message
                 });
+            }
+        }
+
+        private static bool EsDataUrl(string valor)
+        {
+            return !string.IsNullOrWhiteSpace(valor) && valor.TrimStart().StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ObtenerExtension(string mimeType)
+        {
+            return mimeType switch
+            {
+                "image/jpeg" => ".jpg",
+                "image/png" => ".png",
+                "image/gif" => ".gif",
+                "image/webp" => ".webp",
+                "image/bmp" => ".bmp",
+                _ => ".jpg"
+            };
+        }
+
+        private async Task<string> GuardarFotoAsync(string dataUrl)
+        {
+            var comaIndex = dataUrl.IndexOf(',');
+            if (comaIndex < 0)
+            {
+                throw new InvalidOperationException("El formato de la imagen no es válido.");
+            }
+
+            var metadata = dataUrl[..comaIndex];
+            if (!metadata.Contains(";base64", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("El formato de la imagen no es válido.");
+            }
+
+            var base64 = dataUrl[(comaIndex + 1)..];
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(base64);
+            }
+            catch (FormatException)
+            {
+                throw new InvalidOperationException("La imagen cargada está dañada. Selecciona otra foto.");
+            }
+
+            const int maxBytes = 3 * 1024 * 1024; // 3 MB
+            if (bytes.Length > maxBytes)
+            {
+                throw new InvalidOperationException("La imagen es demasiado pesada. Selecciona una foto menor a 3 MB.");
+            }
+
+            var mimeType = metadata.Replace("data:", string.Empty, StringComparison.OrdinalIgnoreCase)
+                                   .Replace(";base64", string.Empty, StringComparison.OrdinalIgnoreCase)
+                                   .Trim();
+
+            if (string.IsNullOrWhiteSpace(mimeType) || !mimeType.StartsWith("image", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Solo se permiten archivos de imagen.");
+            }
+
+            var extension = ObtenerExtension(mimeType);
+            var uploadsFolder = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "uploads", "pacientes");
+            Directory.CreateDirectory(uploadsFolder);
+
+            var fileName = $"{Guid.NewGuid():N}{extension}";
+            var filePath = Path.Combine(uploadsFolder, fileName);
+
+            await System.IO.File.WriteAllBytesAsync(filePath, bytes);
+
+            return $"/uploads/pacientes/{fileName}";
+        }
+
+        private void EliminarFotoExistente(string? rutaRelativa)
+        {
+            if (string.IsNullOrWhiteSpace(rutaRelativa))
+            {
+                return;
+            }
+
+            var trimmed = rutaRelativa.Trim();
+            var relativePath = trimmed.StartsWith('/') ? trimmed[1..] : trimmed;
+            var fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (System.IO.File.Exists(fullPath))
+            {
+                try
+                {
+                    System.IO.File.Delete(fullPath);
+                }
+                catch
+                {
+                    // Si no se puede eliminar, se ignora para no interrumpir la operación principal.
+                }
             }
         }
 

--- a/consultorio-backend/Migrations/20251015120000_AddPacienteFoto.cs
+++ b/consultorio-backend/Migrations/20251015120000_AddPacienteFoto.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConsultorioMedico.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPacienteFoto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FotoUrl",
+                table: "Pacientes",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FotoUrl",
+                table: "Pacientes");
+        }
+    }
+}

--- a/consultorio-backend/Migrations/ConsultorioDbContextModelSnapshot.cs
+++ b/consultorio-backend/Migrations/ConsultorioDbContextModelSnapshot.cs
@@ -262,6 +262,9 @@ namespace ConsultorioMedico.Migrations
                     b.Property<DateTime>("FechaRegistro")
                         .HasColumnType("datetime(6)");
 
+                    b.Property<string>("FotoUrl")
+                        .HasColumnType("longtext");
+
                     b.Property<string>("Genero")
                         .IsRequired()
                         .HasMaxLength(10)

--- a/consultorio-backend/Models/PacienteModel.cs
+++ b/consultorio-backend/Models/PacienteModel.cs
@@ -57,6 +57,9 @@ namespace ConsultorioMedico.API.Models
         [StringLength(500)]
         public string? Alergias { get; set; }
 
+        [Column(TypeName = "longtext")]
+        public string? FotoUrl { get; set; }
+
         public bool Estado { get; set; } = true;
 
         public DateTime FechaRegistro { get; set; } = DateTime.Now;

--- a/consultorio-backend/Program.cs
+++ b/consultorio-backend/Program.cs
@@ -65,6 +65,7 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseCors("AllowAngular");
+app.UseStaticFiles();
 
 
 // app.UseAuthentication();

--- a/consultorio-frontend/src/app/components/pacientes/pacientes.component.css
+++ b/consultorio-frontend/src/app/components/pacientes/pacientes.component.css
@@ -198,6 +198,117 @@
   background-color: #fdfdfd;
 }
 
+.form-row.photo-row {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.photo-field {
+  width: 100%;
+}
+
+.photo-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: center;
+}
+
+.photo-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.photo-preview img {
+  width: 140px;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 18px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+  border: 4px solid rgba(118, 75, 162, 0.15);
+}
+
+.remove-photo {
+  background-color: #dc3545;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.remove-photo:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(220, 53, 69, 0.35);
+}
+
+.photo-placeholder {
+  width: 140px;
+  height: 140px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.1));
+  border: 2px dashed rgba(118, 75, 162, 0.3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #764ba2;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.photo-placeholder i {
+  font-size: 1.8rem;
+}
+
+.photo-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 10px 20px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  border: none;
+  box-shadow: 0 10px 20px rgba(102, 126, 234, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upload-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(102, 126, 234, 0.35);
+}
+
+.upload-btn input[type="file"] {
+  display: none;
+}
+
+.photo-help {
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
+.photo-loading {
+  color: #764ba2;
+  font-weight: 500;
+}
+
+.photo-instructions {
+  margin: 8px 0 20px;
+  color: #6c757d;
+}
+
 .form-section h4 {
   color: #495057;
   margin-bottom: 20px;

--- a/consultorio-frontend/src/app/components/pacientes/pacientes.component.html
+++ b/consultorio-frontend/src/app/components/pacientes/pacientes.component.html
@@ -151,11 +151,54 @@
                 <option value="Viudo">Viudo/a</option>
                 <option value="Union Libre">Unión Libre</option>
               </select>
-            </div>
           </div>
         </div>
 
-        <!-- Información de Contacto -->
+        <div class="form-row photo-row">
+          <div class="form-group full-width photo-field">
+            <label for="fotoPaciente">
+              Foto del paciente
+            </label>
+            <p class="photo-instructions">Sube una imagen o toma una foto directamente desde tu dispositivo.</p>
+            <div class="photo-actions">
+              <ng-container *ngIf="fotoPreview; else sinFoto">
+                <div class="photo-preview">
+                  <img [src]="fotoPreview" alt="Foto del paciente">
+                  <button type="button" class="btn remove-photo" (click)="quitarFoto()">
+                    <i class="fas fa-times"></i>
+                    Quitar foto
+                  </button>
+                </div>
+              </ng-container>
+              <ng-template #sinFoto>
+                <div class="photo-placeholder">
+                  <i class="fas fa-camera"></i>
+                  <span>Sin foto</span>
+                </div>
+              </ng-template>
+              <div class="photo-inputs">
+                <label class="btn btn-secondary upload-btn" for="fotoPaciente">
+                  <i class="fas fa-upload"></i>
+                  <span>{{ fotoPreview ? 'Cambiar foto' : 'Subir o tomar foto' }}</span>
+                  <input
+                    id="fotoPaciente"
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    (change)="onFotoSeleccionada($event)"
+                  >
+                </label>
+                <small class="photo-help">Tamaño máximo recomendado: 5 MB. Formatos compatibles: JPG, PNG, HEIC.</small>
+                <small class="photo-loading" *ngIf="fotoCargando">
+                  <i class="fas fa-spinner fa-spin"></i> Procesando imagen...
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Información de Contacto -->
         <div class="form-section">
           <h4><i class="fas fa-phone"></i> Información de Contacto</h4>
           

--- a/consultorio-frontend/src/app/components/pacientes/pacientes.component.html
+++ b/consultorio-frontend/src/app/components/pacientes/pacientes.component.html
@@ -188,7 +188,7 @@
                     (change)="onFotoSeleccionada($event)"
                   >
                 </label>
-                <small class="photo-help">Tamaño máximo recomendado: 5 MB. Formatos compatibles: JPG, PNG, HEIC.</small>
+                <small class="photo-help">Tamaño máximo recomendado tras el procesamiento: 3 MB. Formatos compatibles: JPG, PNG, HEIC.</small>
                 <small class="photo-loading" *ngIf="fotoCargando">
                   <i class="fas fa-spinner fa-spin"></i> Procesando imagen...
                 </small>

--- a/consultorio-frontend/src/app/components/pacientes/pacientes.component.ts
+++ b/consultorio-frontend/src/app/components/pacientes/pacientes.component.ts
@@ -251,7 +251,7 @@ export class PacientesComponent implements OnInit {
     this.fotoCargando = false;
   }
 
-  onFotoSeleccionada(event: Event): void {
+  async onFotoSeleccionada(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) {
       return;
@@ -273,24 +273,28 @@ export class PacientesComponent implements OnInit {
       return;
     }
 
-    const lector = new FileReader();
     this.fotoCargando = true;
 
-    lector.onload = () => {
-      this.fotoCargando = false;
-      const resultado = lector.result as string;
-      this.fotoPreview = resultado;
-      this.formularioPaciente.patchValue({ foto: resultado });
-      input.value = '';
-    };
+    try {
+      const resultado = await this.procesarImagen(archivo);
+      const tamanoProcesado = this.calcularTamanoDesdeDataUrl(resultado);
+      const tamanoMaximoProcesado = 3 * 1024 * 1024; // 3 MB
 
-    lector.onerror = () => {
+      if (tamanoProcesado > tamanoMaximoProcesado) {
+        alert('La imagen procesada sigue siendo demasiado pesada. Selecciona una foto menor a 3 MB.');
+        this.formularioPaciente.patchValue({ foto: '' });
+        this.fotoPreview = null;
+      } else {
+        this.fotoPreview = resultado;
+        this.formularioPaciente.patchValue({ foto: resultado });
+      }
+    } catch (error) {
+      console.error('Error al procesar la imagen:', error);
+      alert('No se pudo procesar la imagen seleccionada. Intenta con otra foto.');
+    } finally {
       this.fotoCargando = false;
-      alert('No se pudo cargar la imagen seleccionada. Intenta nuevamente.');
       input.value = '';
-    };
-
-    lector.readAsDataURL(archivo);
+    }
   }
 
   quitarFoto(): void {
@@ -361,5 +365,66 @@ export class PacientesComponent implements OnInit {
     });
 
     return mensajes.length ? mensajes : ['Verifica los datos resaltados en rojo.'];
+  }
+
+  private async procesarImagen(archivo: File): Promise<string> {
+    const dataUrl = await this.leerArchivoComoDataUrl(archivo);
+    return this.redimensionarImagenSiEsNecesario(dataUrl);
+  }
+
+  private leerArchivoComoDataUrl(archivo: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const lector = new FileReader();
+      lector.onload = () => resolve(lector.result as string);
+      lector.onerror = () => reject(new Error('No se pudo leer el archivo de imagen.'));
+      lector.readAsDataURL(archivo);
+    });
+  }
+
+  private redimensionarImagenSiEsNecesario(dataUrl: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const imagen = new Image();
+      imagen.onload = () => {
+        const maxDimension = 1024;
+        let { width, height } = imagen;
+
+        if (width <= maxDimension && height <= maxDimension) {
+          resolve(dataUrl);
+          return;
+        }
+
+        if (width > height) {
+          const ratio = maxDimension / width;
+          width = maxDimension;
+          height = Math.round(height * ratio);
+        } else {
+          const ratio = maxDimension / height;
+          height = maxDimension;
+          width = Math.round(width * ratio);
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const contexto = canvas.getContext('2d');
+
+        if (!contexto) {
+          resolve(dataUrl);
+          return;
+        }
+
+        contexto.drawImage(imagen, 0, 0, width, height);
+        resolve(canvas.toDataURL('image/jpeg', 0.85));
+      };
+
+      imagen.onerror = () => reject(new Error('No se pudo procesar la imagen.'));
+      imagen.src = dataUrl;
+    });
+  }
+
+  private calcularTamanoDesdeDataUrl(dataUrl: string): number {
+    const indiceComa = dataUrl.indexOf(',');
+    const base64 = indiceComa >= 0 ? dataUrl.substring(indiceComa + 1) : dataUrl;
+    return Math.ceil((base64.length * 3) / 4);
   }
 }

--- a/consultorio-frontend/src/app/components/pacientes/pacientes.component.ts
+++ b/consultorio-frontend/src/app/components/pacientes/pacientes.component.ts
@@ -22,6 +22,8 @@ export class PacientesComponent implements OnInit {
   pacientesFiltrados: Paciente[] = [];
   cargando = false;
   maxFechaNacimiento = new Date().toISOString().split('T')[0];
+  fotoPreview: string | null = null;
+  fotoCargando = false;
   private readonly instruccionesCampos: Record<string, string> = {
     cedula: 'Cédula: ingresa 10 dígitos numéricos sin espacios ni guiones.',
     nombres: 'Nombres: escribe al menos dos caracteres alfabéticos.',
@@ -62,7 +64,8 @@ export class PacientesComponent implements OnInit {
       contactoEmergenciaRelacion: [''],
       alergias: [''],
       medicamentosActuales: [''],
-      enfermedadesCronicas: ['']
+      enfermedadesCronicas: [''],
+      foto: ['']
     });
   }
 
@@ -98,6 +101,8 @@ export class PacientesComponent implements OnInit {
   nuevoPaciente(): void {
     this.pacienteSeleccionado = null;
     this.formularioPaciente.reset();
+    this.fotoPreview = null;
+    this.fotoCargando = false;
     this.mostrarFormulario = true;
   }
 
@@ -122,6 +127,11 @@ export class PacientesComponent implements OnInit {
       medicamentosActuales: paciente.medicamentosActuales?.join(', '),
       enfermedadesCronicas: paciente.enfermedadesCronicas?.join(', ')
     });
+    this.formularioPaciente.patchValue({
+      foto: paciente.fotoUrl ?? ''
+    });
+    this.fotoPreview = paciente.fotoUrl ?? null;
+    this.fotoCargando = false;
     this.mostrarFormulario = true;
   }
 
@@ -162,7 +172,8 @@ export class PacientesComponent implements OnInit {
       enfermedadesCronicas: formData.enfermedadesCronicas ? formData.enfermedadesCronicas.split(',').map((e: string) => e.trim()) : [],
       fechaRegistro: this.pacienteSeleccionado?.fechaRegistro || new Date(),
       activo: this.pacienteSeleccionado?.activo ?? true,
-      email: formData.email
+      email: formData.email,
+      fotoUrl: formData.foto || undefined
     };
 
     if (this.pacienteSeleccionado) {
@@ -236,6 +247,56 @@ export class PacientesComponent implements OnInit {
     this.mostrarFormulario = false;
     this.pacienteSeleccionado = null;
     this.formularioPaciente.reset();
+    this.fotoPreview = null;
+    this.fotoCargando = false;
+  }
+
+  onFotoSeleccionada(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) {
+      return;
+    }
+
+    const archivo = input.files[0];
+    const esImagen = archivo.type.startsWith('image/');
+    const tamanoMaximo = 5 * 1024 * 1024; // 5 MB
+
+    if (!esImagen) {
+      alert('Selecciona un archivo de imagen válido (JPG, PNG, HEIC, etc.).');
+      input.value = '';
+      return;
+    }
+
+    if (archivo.size > tamanoMaximo) {
+      alert('La imagen es demasiado pesada. Selecciona una foto menor a 5 MB.');
+      input.value = '';
+      return;
+    }
+
+    const lector = new FileReader();
+    this.fotoCargando = true;
+
+    lector.onload = () => {
+      this.fotoCargando = false;
+      const resultado = lector.result as string;
+      this.fotoPreview = resultado;
+      this.formularioPaciente.patchValue({ foto: resultado });
+      input.value = '';
+    };
+
+    lector.onerror = () => {
+      this.fotoCargando = false;
+      alert('No se pudo cargar la imagen seleccionada. Intenta nuevamente.');
+      input.value = '';
+    };
+
+    lector.readAsDataURL(archivo);
+  }
+
+  quitarFoto(): void {
+    this.fotoPreview = null;
+    this.fotoCargando = false;
+    this.formularioPaciente.patchValue({ foto: '' });
   }
 
   // Getter para validación del formulario

--- a/consultorio-frontend/src/app/models/paciente.model.ts
+++ b/consultorio-frontend/src/app/models/paciente.model.ts
@@ -25,4 +25,5 @@ export interface Paciente {
   fechaRegistro?: Date;
   activo: boolean;
   nombreCompleto?: string;
+  fotoUrl?: string;
 }

--- a/consultorio-frontend/src/app/services/pacientes.service.ts
+++ b/consultorio-frontend/src/app/services/pacientes.service.ts
@@ -44,6 +44,7 @@ type PacientePayload = Omit<PacienteApi, 'pacienteId' | 'fechaRegistro'> & {
 })
 export class PacientesService {
   private readonly baseUrl = `${environment.apiUrl.replace(/\/$/, '')}/api/Pacientes`;
+  private readonly apiRoot = environment.apiUrl.replace(/\/$/, '');
 
   constructor(private readonly http: HttpClient) {}
 
@@ -152,7 +153,7 @@ export class PacientesService {
       enfermedadesCronicas: [],
       fechaRegistro,
       activo: api.estado,
-      fotoUrl: api.fotoUrl ?? undefined
+      fotoUrl: this.normalizarFotoUrl(api.fotoUrl)
     };
   }
 
@@ -184,8 +185,51 @@ export class PacientesService {
       alergias: this.stringifyLista(paciente.alergias),
       estado: paciente.activo,
       fechaRegistro: paciente.fechaRegistro?.toISOString(),
-      fotoUrl: paciente.fotoUrl
+      fotoUrl: this.prepararFotoParaEnvio(paciente.fotoUrl)
     };
+  }
+
+  private normalizarFotoUrl(fotoUrl?: string): string | undefined {
+    if (!fotoUrl) {
+      return undefined;
+    }
+
+    const trimmed = fotoUrl.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    if (trimmed.startsWith('data:') || /^https?:\/\//i.test(trimmed)) {
+      return trimmed;
+    }
+
+    if (trimmed.startsWith('/')) {
+      return `${this.apiRoot}${trimmed}`;
+    }
+
+    return `${this.apiRoot}/${trimmed}`;
+  }
+
+  private prepararFotoParaEnvio(fotoUrl?: string): string | undefined {
+    if (!fotoUrl) {
+      return undefined;
+    }
+
+    const trimmed = fotoUrl.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    if (trimmed.startsWith('data:')) {
+      return trimmed;
+    }
+
+    if (trimmed.startsWith(this.apiRoot)) {
+      const relative = trimmed.substring(this.apiRoot.length);
+      return relative.startsWith('/') ? relative : `/${relative}`;
+    }
+
+    return trimmed;
   }
 
   private parseContactoEmergencia(nombre?: string, telefono?: string): Paciente['contactoEmergencia'] | undefined {

--- a/consultorio-frontend/src/app/services/pacientes.service.ts
+++ b/consultorio-frontend/src/app/services/pacientes.service.ts
@@ -31,6 +31,7 @@ interface PacienteApi {
   alergias?: string;
   estado: boolean;
   fechaRegistro?: string;
+  fotoUrl?: string;
 }
 
 type PacientePayload = Omit<PacienteApi, 'pacienteId' | 'fechaRegistro'> & {
@@ -150,7 +151,8 @@ export class PacientesService {
       medicamentosActuales: [],
       enfermedadesCronicas: [],
       fechaRegistro,
-      activo: api.estado
+      activo: api.estado,
+      fotoUrl: api.fotoUrl ?? undefined
     };
   }
 
@@ -181,7 +183,8 @@ export class PacientesService {
       tipoSangre: paciente.tipoSangre,
       alergias: this.stringifyLista(paciente.alergias),
       estado: paciente.activo,
-      fechaRegistro: paciente.fechaRegistro?.toISOString()
+      fechaRegistro: paciente.fechaRegistro?.toISOString(),
+      fotoUrl: paciente.fotoUrl
     };
   }
 


### PR DESCRIPTION
## Summary
- add optional `FotoUrl` column to `PacienteModel` and include it in patient updates and migrations
- expose patient photos through the Angular models/service and persist them when creating or editing patients
- enhance the patient registration form with image upload or capture support, live preview, and updated styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d88cc6f5ec832f822d1906e3116134